### PR TITLE
Fixed stackoverflow when logging internal

### DIFF
--- a/src/log4net/Repository/Hierarchy/Logger.cs
+++ b/src/log4net/Repository/Hierarchy/Logger.cs
@@ -599,6 +599,7 @@ namespace log4net.Repository.Hierarchy
 			//
 			if (!m_hierarchy.EmittedNoAppenderWarning && writes == 0) 
 			{
+                m_hierarchy.EmittedNoAppenderWarning = true;
 				LogLog.Debug(declaringType, "No appenders could be found for logger [" + Name + "] repository [" + Repository.Name + "]");
 				LogLog.Debug(declaringType, "Please initialize the log4net system properly.");
 				try
@@ -614,7 +615,6 @@ namespace log4net.Repository.Hierarchy
 				{
 					// Insufficient permissions to display info from the AppDomain
 				}
-				m_hierarchy.EmittedNoAppenderWarning = true;
 			}
 		}
 


### PR DESCRIPTION
When internal logging is on, manually shutdown and stderr/stdout
redirection is performed in log4net we get infinite loop.  This fixes
the stack overflow but does not fix the fact that logging is done after
the hierarchy was shutdown