### PR TITLE
Use UTC internally to avoid ambiguous timestamps

### DIFF
--- a/src/Core/TimeEvaluator.cs
+++ b/src/Core/TimeEvaluator.cs
@@ -39,9 +39,9 @@ namespace log4net.Core
         private int m_interval;
 
         /// <summary>
-        /// The time of last check. This gets updated when the object is created and when the evaluator triggers.
+        /// The UTC time of last check. This gets updated when the object is created and when the evaluator triggers.
         /// </summary>
-        private DateTime m_lasttime;
+        private DateTime m_lastTimeUtc;
 
         /// <summary>
         /// The default time threshold for triggering in seconds. Zero means it won't trigger at all.
@@ -84,7 +84,7 @@ namespace log4net.Core
         public TimeEvaluator(int interval)
         {
             m_interval = interval;
-            m_lasttime = DateTime.Now;
+            m_lastTimeUtc = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -131,11 +131,11 @@ namespace log4net.Core
 
             lock (this) // avoid triggering multiple times
             {
-                TimeSpan passed = DateTime.Now.Subtract(m_lasttime);
+                TimeSpan passed = DateTime.UtcNow.Subtract(m_lastTimeUtc);
 
                 if (passed.TotalSeconds > m_interval)
                 {
-                    m_lasttime = DateTime.Now;
+                    m_lastTimeUtc = DateTime.UtcNow;
                     return true;
                 }
                 else

--- a/src/Layout/Pattern/RelativeTimePatternConverter.cs
+++ b/src/Layout/Pattern/RelativeTimePatternConverter.cs
@@ -50,7 +50,7 @@ namespace log4net.Layout.Pattern
 		/// </remarks>
 		override protected void Convert(TextWriter writer, LoggingEvent loggingEvent)
 		{
-			writer.Write( TimeDifferenceInMillis(LoggingEvent.StartTime, loggingEvent.TimeStamp).ToString(System.Globalization.NumberFormatInfo.InvariantInfo) );
+			writer.Write( TimeDifferenceInMillis(LoggingEvent.StartTimeUtc, loggingEvent.TimeStampUtc).ToString(System.Globalization.NumberFormatInfo.InvariantInfo) );
 		}
 
 		/// <summary>

--- a/src/Layout/Pattern/UtcDatePatternConverter.cs
+++ b/src/Layout/Pattern/UtcDatePatternConverter.cs
@@ -67,7 +67,7 @@ namespace log4net.Layout.Pattern
 		{
 			try 
 			{
-				m_dateFormatter.FormatDate(loggingEvent.TimeStamp.ToUniversalTime(), writer);
+				m_dateFormatter.FormatDate(loggingEvent.TimeStampUtc, writer);
 			}
 			catch (Exception ex) 
 			{

--- a/src/Layout/RawUtcTimeStampLayout.cs
+++ b/src/Layout/RawUtcTimeStampLayout.cs
@@ -66,7 +66,7 @@ namespace log4net.Layout
 		/// </remarks>
 		public virtual object Format(LoggingEvent loggingEvent)
 		{
-			return loggingEvent.TimeStamp.ToUniversalTime();
+			return loggingEvent.TimeStampUtc;
 		}
 
 		#endregion

--- a/src/Layout/XmlLayoutSchemaLog4j.cs
+++ b/src/Layout/XmlLayoutSchemaLog4j.cs
@@ -180,7 +180,7 @@ method="run" file="Generator.java" line="94"/>
 			// We must convert the TimeStamp to UTC before performing any mathematical
 			// operations. This allows use to take into account discontinuities
 			// caused by daylight savings time transitions.
-			TimeSpan timeSince1970 = loggingEvent.TimeStamp.ToUniversalTime() - s_date1970;
+			TimeSpan timeSince1970 = loggingEvent.TimeStampUtc - s_date1970;
 
 			writer.WriteAttributeString("timestamp", XmlConvert.ToString((long)timeSince1970.TotalMilliseconds));
 			writer.WriteAttributeString("level", loggingEvent.Level.DisplayName);

--- a/src/Util/LogLog.cs
+++ b/src/Util/LogLog.cs
@@ -58,7 +58,7 @@ namespace log4net.Util
         public static event LogReceivedEventHandler LogReceived;
 
         private readonly Type source;
-        private readonly DateTime timeStamp;
+        private readonly DateTime timeStampUtc;
         private readonly string prefix;
         private readonly string message;
         private readonly Exception exception;
@@ -76,7 +76,15 @@ namespace log4net.Util
         /// </summary>
 	    public DateTime TimeStamp
 	    {
-            get { return timeStamp; }
+            get { return timeStampUtc.ToLocalTime(); }
+	    }
+
+        /// <summary>
+        /// The UTC DateTime stamp of when the internal message was received.
+        /// </summary>
+        public DateTime TimeStampUtc
+        {
+            get { return timeStampUtc; }
 	    }
 
         /// <summary>
@@ -132,7 +140,7 @@ namespace log4net.Util
         /// <param name="exception"></param>
 	    public LogLog(Type source, string prefix, string message, Exception exception)
 	    {
-            timeStamp = DateTime.Now;
+            timeStampUtc = DateTime.UtcNow;
 	        
             this.source = source;
 	        this.prefix = prefix;

--- a/src/Util/OnlyOnceErrorHandler.cs
+++ b/src/Util/OnlyOnceErrorHandler.cs
@@ -81,7 +81,7 @@ namespace log4net.Util
 		/// </summary>
 		public void Reset()
 		{
-			m_enabledDate = DateTime.MinValue;
+			m_enabledDateUtc = DateTime.MinValue;
 			m_errorCode = ErrorCode.GenericFailure;
 			m_exception = null;
 			m_message = null;
@@ -121,7 +121,7 @@ namespace log4net.Util
         /// </para>
         /// </remarks>
         public virtual void FirstError(string message, Exception e, ErrorCode errorCode) {
-            m_enabledDate = DateTime.Now;
+            m_enabledDateUtc = DateTime.UtcNow;
             m_errorCode = errorCode;
             m_exception = e;
             m_message = message;
@@ -182,12 +182,24 @@ namespace log4net.Util
 		}
 
 		/// <summary>
-		/// The date the first error that trigged this error handler occured.
+		/// The date the first error that trigged this error handler occurred, or <see cref="DateTime.MinValue"/> if it has not been triggered.
 		/// </summary>
 		public DateTime EnabledDate
 		{
-			get { return m_enabledDate; }
+			get 
+            {
+                if (m_enabledDateUtc == DateTime.MinValue) return DateTime.MinValue;
+                return m_enabledDateUtc.ToLocalTime(); 
+            }
 		}
+
+        /// <summary>
+        /// The UTC date the first error that trigged this error handler occured, or <see cref="DateTime.MinValue"/> if it has not been triggered.
+        /// </summary>
+        public DateTime EnabledDateUtc
+        {
+            get { return m_enabledDateUtc; }
+        }
 
 		/// <summary>
 		/// The message from the first error that trigged this error handler.
@@ -224,9 +236,9 @@ namespace log4net.Util
 		#region Private Instance Fields
 
 		/// <summary>
-		/// The date the error was recorded.
+		/// The UTC date the error was recorded.
 		/// </summary>
-		private DateTime m_enabledDate;
+		private DateTime m_enabledDateUtc;
 
 		/// <summary>
 		/// Flag to indicate if it is the first error

--- a/src/Util/SystemInfo.cs
+++ b/src/Util/SystemInfo.cs
@@ -394,9 +394,35 @@ namespace log4net.Util
 		/// will be set per AppDomain.
 		/// </para>
 		/// </remarks>
+        [Obsolete("Use ProcessStartTimeUtc and convert to local time if needed.")]
 		public static DateTime ProcessStartTime
 		{
-			get { return s_processStartTime; }
+			get { return s_processStartTimeUtc.ToLocalTime(); }
+		}
+
+        /// <summary>
+        /// Get the UTC start time for the current process.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the UTC time at which the log4net library was loaded into the
+        /// AppDomain. Due to reports of a hang in the call to <c>System.Diagnostics.Process.StartTime</c>
+        /// this is not the start time for the current process.
+        /// </para>
+        /// <para>
+        /// The log4net library should be loaded by an application early during its
+        /// startup, therefore this start time should be a good approximation for
+        /// the actual start time.
+        /// </para>
+        /// <para>
+        /// Note that AppDomains may be loaded and unloaded within the
+        /// same process without the process terminating, however this start time
+        /// will be set per AppDomain.
+        /// </para>
+        /// </remarks>
+        public static DateTime ProcessStartTimeUtc
+        {
+            get { return s_processStartTimeUtc; }
 		}
 
 		/// <summary>
@@ -1174,7 +1200,7 @@ namespace log4net.Util
 		/// <summary>
 		/// Start time for the current process.
 		/// </summary>
-		private static DateTime s_processStartTime = DateTime.Now;
+		private static DateTime s_processStartTimeUtc = DateTime.UtcNow;
 
 		#endregion
 

--- a/tests/src/Core/FixingTest.cs
+++ b/tests/src/Core/FixingTest.cs
@@ -131,7 +131,7 @@ namespace log4net.Tests.Core
 			loggingEventData.Domain = "ReallySimpleApp";
 			loggingEventData.LocationInfo = new LocationInfo(typeof(FixingTest).Name, "Main", "Class1.cs", "29"); //Completely arbitary
 			loggingEventData.ThreadName = Thread.CurrentThread.Name;
-			loggingEventData.TimeStamp = DateTime.Today;
+			loggingEventData.TimeStampUtc = DateTime.UtcNow.Date;
 			loggingEventData.ExceptionString = "Exception occured here";
 			loggingEventData.UserName = "TestUser";
 			return loggingEventData;
@@ -149,7 +149,8 @@ namespace log4net.Tests.Core
 			Assert.AreEqual("log4net.Tests.Core.FixingTest", loggingEventData.LoggerName, "LoggerName is incorrect");
 			Assert.AreEqual(LogManager.GetRepository(TEST_REPOSITORY), loggingEvent.Repository, "Repository is incorrect");
 			Assert.AreEqual(Thread.CurrentThread.Name, loggingEventData.ThreadName, "ThreadName is incorrect");
-			Assert.IsNotNull(loggingEventData.TimeStamp, "TimeStamp is incorrect");
+            // This test is redundant as loggingEventData.TimeStamp is a value type and cannot be null
+            // Assert.IsNotNull(loggingEventData.TimeStampUtc, "TimeStamp is incorrect");
 			Assert.AreEqual("TestUser", loggingEventData.UserName, "UserName is incorrect");
 			Assert.AreEqual("Logging event works", loggingEvent.RenderedMessage, "Message is incorrect");
 		}

--- a/tests/src/Layout/XmlLayoutTest.cs
+++ b/tests/src/Layout/XmlLayoutTest.cs
@@ -73,7 +73,7 @@ namespace log4net.Tests.Layout
 			ed.LoggerName = "TestLogger";
 			ed.Message = "Test message";
 			ed.ThreadName = "TestThread";
-			ed.TimeStamp = DateTime.Today;
+			ed.TimeStampUtc = DateTime.Today.ToUniversalTime();
 			ed.UserName = "TestRunner";
 			ed.Properties = new PropertiesDictionary();
 


### PR DESCRIPTION
Resubmitting replacement for #24 

Rebased to latest trunk and fixed backwards compatibility issue of binary serialization of LoggingEvent.
