### PR TITLE
LOG4NET-554 Use AsyncLocal for LogicalThreadContext

### DIFF
--- a/netstandard/log4net.tests/log4net.tests.xproj
+++ b/netstandard/log4net.tests/log4net.tests.xproj
@@ -36,6 +36,7 @@ limitations under the License.
     <Compile Include="../../tests/src/Appender/SmtpPickupDirAppenderTest.cs" />
     <Compile Include="../../tests/src/Appender/StringAppender.cs" />
     <Compile Include="../../tests/src/Appender/TraceAppenderTest.cs" />
+    <Compile Include="../../tests/src/Context/LogicalThreadContextTest.cs" />
     <Compile Include="../../tests/src/Context/ThreadContextTest.cs" />
     <Compile Include="../../tests/src/Core/**/*.cs" />
     <Compile Include="../../tests/src/DateFormatter/**/*.cs" />

--- a/netstandard/log4net.tests/project.json
+++ b/netstandard/log4net.tests/project.json
@@ -11,6 +11,7 @@
       "../../tests/src/Appender/SmtpPickupDirAppenderTest.cs",
       "../../tests/src/Appender/StringAppender.cs",
       "../../tests/src/Appender/TraceAppenderTest.cs",
+      "../../tests/src/Context/LogicalThreadContextTest.cs",
       "../../tests/src/Context/ThreadContextTest.cs",
       "../../tests/src/Core/**/*.cs",
       "../../tests/src/DateFormatter/**/*.cs",

--- a/netstandard/log4net/log4net.xproj
+++ b/netstandard/log4net/log4net.xproj
@@ -161,7 +161,7 @@ limitations under the License.
     <Compile Include="../../src/Layout/XmlLayout.cs" />
     <Compile Include="../../src/Layout/XmlLayoutBase.cs" />
     <Compile Include="../../src/Layout/XmlLayoutSchemaLog4j.cs" />
-    <!--<Compile Include="../../src/LogicalThreadContext.cs" />-->
+    <Compile Include="../../src/LogicalThreadContext.cs" />
     <Compile Include="../../src/LogManager.cs" />
     <Compile Include="../../src/MDC.cs" />
     <Compile Include="../../src/NDC.cs" />
@@ -201,9 +201,9 @@ limitations under the License.
     <Compile Include="../../src/Util/ILogExtensions.cs" />
     <Compile Include="../../src/Util/LevelMapping.cs" />
     <Compile Include="../../src/Util/LevelMappingEntry.cs" />
-    <!--<Compile Include="../../src/Util/LogicalThreadContextProperties.cs" />-->
+    <Compile Include="../../src/Util/LogicalThreadContextProperties.cs" />
     <Compile Include="../../src/Util/LogicalThreadContextStack.cs" />
-    <!--<Compile Include="../../src/Util/LogicalThreadContextStacks.cs" />-->
+    <Compile Include="../../src/Util/LogicalThreadContextStacks.cs" />
     <Compile Include="../../src/Util/LogLog.cs" />
     <!--<Compile Include="../../src/Util/NativeError.cs" />-->
     <Compile Include="../../src/Util/NullDictionaryEnumerator.cs" />

--- a/netstandard/log4net/project.json
+++ b/netstandard/log4net/project.json
@@ -16,7 +16,6 @@
             "../../src/Appender/NetSendAppender.cs",
             "../../src/Appender/RemotingAppender.cs",
             "../../src/Appender/SmtpAppender.cs",
-            "../../src/LogicalThreadContext.cs",
             "../../src/Config/DOMConfigurator.cs",
             "../../src/Config/DOMConfiguratorAttribute.cs",
             "../../src/Config/Log4NetConfigurationSectionHandler.cs",
@@ -30,8 +29,6 @@
             "../../src/Plugin/RemoteLoggingServerPlugin.cs",
             "../../src/Util/PatternStringConverters/AppSettingPatternConverter.cs",
             "../../src/Util/PatternStringConverters/EnvironmentFolderPathPatternConverter.cs",
-            "../../src/Util/LogicalThreadContextProperties.cs",
-            "../../src/Util/LogicalThreadContextStacks.cs",
             "../../src/Util/NativeError.cs",
             "../../src/Util/WindowsSecurityContext.cs"
           ]

--- a/src/Core/LoggingEvent.cs
+++ b/src/Core/LoggingEvent.cs
@@ -461,7 +461,7 @@ namespace log4net.Core
 
 		#region Protected Instance Constructors
 
-#if !(NETCF || NETSTANDARD1_3)
+#if !NETCF
 
 		/// <summary>
 		/// Serialization constructor
@@ -814,7 +814,7 @@ namespace log4net.Core
 			{
 				if (m_data.ThreadName == null && this.m_cacheUpdatable)
 				{
-#if NETCF || NETSTANDARD1_3
+#if NETCF
 					// Get thread ID only
 					m_data.ThreadName = SystemInfo.CurrentThreadId.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
 #else
@@ -1394,7 +1394,7 @@ namespace log4net.Core
 			{
 				compositeProperties.Add(m_eventProperties);
 			}
-#if !(NETCF || NETSTANDARD1_3)
+#if !NETCF
 			PropertiesDictionary logicalThreadProperties = LogicalThreadContext.Properties.GetProperties(false);
 			if (logicalThreadProperties != null)
 			{

--- a/src/Util/PatternStringConverters/PropertyPatternConverter.cs
+++ b/src/Util/PatternStringConverters/PropertyPatternConverter.cs
@@ -68,7 +68,7 @@ namespace log4net.Util.PatternStringConverters
 		{
 			CompositeProperties compositeProperties = new CompositeProperties();
 
-#if !(NETCF || NETSTANDARD1_3)
+#if !NETCF
 			PropertiesDictionary logicalThreadProperties = LogicalThreadContext.Properties.GetProperties(false);
 			if (logicalThreadProperties != null)
 			{

--- a/src/site/xdoc/release/framework-support.xml
+++ b/src/site/xdoc/release/framework-support.xml
@@ -614,9 +614,6 @@ limitations under the License.
                       <li>anything related to ASP.NET (trace appender
                       and several pattern converters)</li>
                       <li>.NET Remoting</li>
-                      <li><code>log4net.LogicalThreadContext</code>
-                      and the associated properties and stack
-                      classes</li>
                       <li>the colored console appender</li>
                       <li>the event log appender</li>
                       <li>The <code>NetSendAppender</code></li>

--- a/tests/src/Context/LogicalThreadContextTest.cs
+++ b/tests/src/Context/LogicalThreadContextTest.cs
@@ -17,7 +17,7 @@
 //
 #endregion
 
-#if NET_4_5
+#if NET_4_5 || NETSTANDARD1_3
 using System;
 using System.Threading.Tasks;
 using System.Linq;

--- a/tests/src/Utils.cs
+++ b/tests/src/Utils.cs
@@ -114,7 +114,7 @@ namespace log4net.Tests
         internal static void RemovePropertyFromAllContexts() {
             GlobalContext.Properties.Remove(PROPERTY_KEY);
             ThreadContext.Properties.Remove(PROPERTY_KEY);
-#if !(NETCF || NETSTANDARD1_3)
+#if !NETCF
             LogicalThreadContext.Properties.Remove(PROPERTY_KEY);
 #endif
         }


### PR DESCRIPTION
Replaces System.Runtime.Remoting.Messaging.CallContext which was removed in .NETStandard, with System.Threading.AsyncLocal which exists in .NET 4.6 and above